### PR TITLE
handle most link cases correctly

### DIFF
--- a/html_parser/main.go
+++ b/html_parser/main.go
@@ -50,8 +50,7 @@ func loadSource(reader *io.Reader) []link {
 
 func sanatiseLinktext(linkText string) string {
 	noNewLines := strings.Replace(linkText, "\n", "", -1)
-	trimmed := strings.Trim(noNewLines, " ")
-	return trimmed
+	return noNewLines
 }
 
 func handleANode(n *html.Node) link {
@@ -59,11 +58,29 @@ func handleANode(n *html.Node) link {
 	var newLink link
 	for _, a := range n.Attr {
 		if a.Key == "href" {
-			newLink = link{Href: a.Val, Text: sanatiseLinktext(n.FirstChild.Data)}
+			newLink = link{Href: a.Val, Text: strings.Trim(getAText(n, ""), " ")}
 			break
 		}
 	}
 	return newLink
+}
+
+func getAText(n *html.Node, linkText string) string {
+	if n.Type == html.TextNode {
+		fmt.Println(n.Data)
+		return sanatiseLinktext(n.Data)
+	}
+
+	if n.Type != html.ElementNode {
+		return ""
+	}
+
+	var new string
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		new += getAText(c, linkText)
+	}
+
+	return new
 }
 
 func recursiveParse(n *html.Node, links []link) []link {

--- a/html_parser/main.go
+++ b/html_parser/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+type link struct {
+	Href string
+	Text string
+}
+
+func main() {
+	file, _ := openSource("tests/test4.html")
+
+	loadSource(file)
+}
+
+// Loading and opening the parsing file
+func openSource(fileLoc string) (*io.Reader, error) {
+	file, err := os.Open(fileLoc)
+
+	if err != nil {
+		fmt.Println("Unable to open file:", fileLoc, ":", err)
+	}
+
+	var reader io.Reader
+	reader = file
+	return &reader, nil
+
+}
+
+func loadSource(reader *io.Reader) []link {
+
+	node, err := html.Parse(*reader)
+
+	if err != nil {
+		fmt.Println("Unable to parse HTML source:", err)
+		os.Exit(1)
+	}
+
+	var linksList = make([]link, 0)
+	linksList = recursiveParse(node, linksList)
+	return linksList
+}
+
+func sanatiseLinktext(linkText string) string {
+	noNewLines := strings.Replace(linkText, "\n", "", -1)
+	trimmed := strings.Trim(noNewLines, " ")
+	return trimmed
+}
+
+func handleANode(n *html.Node) link {
+
+	var newLink link
+	for _, a := range n.Attr {
+		if a.Key == "href" {
+			newLink = link{Href: a.Val, Text: sanatiseLinktext(n.FirstChild.Data)}
+			break
+		}
+	}
+	return newLink
+}
+
+func recursiveParse(n *html.Node, links []link) []link {
+
+	if n.Type == html.ElementNode && n.Data == "a" {
+		newLink := handleANode(n)
+		links = append(links, newLink)
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		links = recursiveParse(c, links)
+	}
+
+	return links
+}

--- a/html_parser/main_test.go
+++ b/html_parser/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseHtmlFile(t *testing.T) {
+	fileName := "tests/basetest.html"
+	expected := []link{{Href: "/other-page", Text: "A link to another page"}}
+
+	file, _ := openSource(fileName)
+	actual := loadSource(file)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFile1(t *testing.T) {
+	fileName := "tests/test1.html"
+	expected := []link{{Href: "/other-page", Text: "A link to another page"}}
+
+	file, _ := openSource(fileName)
+	actual := loadSource(file)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFile2(t *testing.T) {
+	fileName := "tests/test2.html"
+	expected := []link{{Href: "https://www.twitter.com/joncalhoun", Text: "Check me out on twitter"}, {Href: "https://github.com/gophercises", Text: "Gophercises is on"}} // Github!
+
+	file, _ := openSource(fileName)
+	actual := loadSource(file)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFile3(t *testing.T) {
+	fileName := "tests/test3.html"
+	expected := []link{{Href: "#", Text: "Login"}, {Href: "/lost", Text: "Lost? Need help?"}, {Href: "https://twitter.com/marcusolsson", Text: "@marcusolsson"}}
+
+	file, _ := openSource(fileName)
+	actual := loadSource(file)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFile4(t *testing.T) {
+	fileName := "tests/test4.html"
+	expected := []link{{Href: "/dog-cat", Text: "dog cat"}}
+
+	file, _ := openSource(fileName)
+	actual := loadSource(file)
+
+	assert.Equal(t, expected, actual)
+}

--- a/html_parser/main_test.go
+++ b/html_parser/main_test.go
@@ -28,7 +28,7 @@ func TestFile1(t *testing.T) {
 
 func TestFile2(t *testing.T) {
 	fileName := "tests/test2.html"
-	expected := []link{{Href: "https://www.twitter.com/joncalhoun", Text: "Check me out on twitter"}, {Href: "https://github.com/gophercises", Text: "Gophercises is on"}} // Github!
+	expected := []link{{Href: "https://www.twitter.com/joncalhoun", Text: "Check me out on twitter"}, {Href: "https://github.com/gophercises", Text: "Gophercises is on Github!"}} // Github!
 
 	file, _ := openSource(fileName)
 	actual := loadSource(file)

--- a/html_parser/tests/basetest.html
+++ b/html_parser/tests/basetest.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        <a href="/other-page">A link to another page</a>
+    </body>
+</html>

--- a/html_parser/tests/test1.html
+++ b/html_parser/tests/test1.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1>Hello!</h1>
+  <a href="/other-page">A link to another page</a>
+</body>
+</html>

--- a/html_parser/tests/test2.html
+++ b/html_parser/tests/test2.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body>
+  <h1>Social stuffs</h1>
+  <div>
+    <a href="https://www.twitter.com/joncalhoun">
+      Check me out on twitter
+      <i class="fa fa-twitter" aria-hidden="true"></i>
+    </a>
+    <a href="https://github.com/gophercises">
+      Gophercises is on <strong>Github</strong>!
+    </a>
+  </div>
+</body>
+</html>

--- a/html_parser/tests/test3.html
+++ b/html_parser/tests/test3.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="ie ie6 lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="ie ie7 lt-ie9 lt-ie8"        lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="ie ie8 lt-ie9"               lang="en"> <![endif]-->
+<!--[if IE 9]>    <html class="ie ie9"                      lang="en"> <![endif]-->
+<!--[if !IE]><!-->
+<html lang="en" class="no-ie">
+<!--<![endif]-->
+
+<head>
+  <title>Gophercises - Coding exercises for budding gophers</title>
+</head>
+
+<body>
+  <section class="header-section">
+    <div class="jumbo-content">
+      <div class="pull-right login-section">
+        Already have an account?
+        <a href="#" class="btn btn-login">Login <i class="fa fa-sign-in" aria-hidden="true"></i></a>
+      </div>
+      <center>
+        <img src="https://gophercises.com/img/gophercises_logo.png" style="max-width: 85%; z-index: 3;">
+        <h1>coding exercises for budding gophers</h1>
+        <br/>
+        <form action="/do-stuff" method="post">
+          <div class="input-group">
+            <input type="email" id="drip-email" name="fields[email]" class="btn-input" placeholder="Email Address" required>
+            <button class="btn btn-success btn-lg" type="submit">Sign me up!</button>
+            <a href="/lost">Lost? Need help?</a>
+          </div>
+        </form>
+        <p class="disclaimer disclaimer-box">Gophercises is 100% FREE, but is currently in beta. There will be bugs, and things will be changing significantly over the coming weeks.</p>
+      </center>
+    </div>
+  </section>
+  <section class="footer-section">
+    <div class="row">
+      <div class="col-md-6 col-md-offset-1 vcenter">
+        <div class="quote">
+          "Success is no accident. It is hard work, perseverance, learning, studying, sacrifice and most of all, love of what you are doing or learning to do." - Pele
+        </div>
+      </div>
+      <div class="col-md-4 col-md-offset-0 vcenter">
+        <center>
+          <img src="https://gophercises.com/img/gophercises_lifting.gif" style="width: 80%">
+          <br/>
+          <br/>
+        </center>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-10 col-md-offset-1">
+        <center>
+          <p class="disclaimer">
+            Artwork created by Marcus Olsson (<a href="https://twitter.com/marcusolsson">@marcusolsson</a>), animated by Jon Calhoun (that's me!), and inspired by the original Go Gopher created by Renee French.
+          </p>
+        </center>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/html_parser/tests/test4.html
+++ b/html_parser/tests/test4.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <a href="/dog-cat">dog cat <!-- commented text SHOULD NOT be included! --></a>
+</body>
+</html>


### PR DESCRIPTION
Handle all provided test cases except for formatted text values. 
I think you'd need to enumerate all possible values like `strong`, `em` etc etc to ensure you only parse tags that *format* text and not irrelevant child tags to the `<a>` node.